### PR TITLE
Support Wildcards

### DIFF
--- a/controllers/cachedcertificate_utils.go
+++ b/controllers/cachedcertificate_utils.go
@@ -99,11 +99,13 @@ func getUpstreamCertificateName(dnsNames ...string) string {
 	sort.Strings(names)
 
 	resourceName := strings.Join(names, "-")
+	resourceName = strings.ReplaceAll(resourceName, "*", "x")
 
 	if len(resourceName) > maxSecretNameLength {
 		// the "-3" is to ensure space for the "cc-" prefix
 		resourceName = resourceName[:hashPrefixLength-3] + genHash(resourceName)
 	}
+	resourceName = strings.ReplaceAll(resourceName, "\\", "x")
 
 	return "cc-" + resourceName
 }


### PR DESCRIPTION
This solves #3 

Changes
- Replacing occurances of "*" in the secret name to instead be "x"
- An issue occured where the hashing would produce backslash characters - now replacing occurances of backslash characters with an "x"

Benefits
- Cached certificates such as:
- ```
  ---
  apiVersion: cert-manager.io/v1
  kind: ClusterIssuer
  metadata:
    name: selfsigned-issuer
  spec:
    selfSigned: {}
  ---
  apiVersion: cache.weavelab.xyz/v1alpha1
  kind: CachedCertificate
  metadata:
    name: wildcard-cert
  spec:
    issuerRef:
      name: selfsigned-issuer
      kind: ClusterIssuer
    dnsNames:
      - "*.example.com"
   ```
  Work without problems! 🎉 
